### PR TITLE
More consistent code style

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -40,8 +40,8 @@ function func() {
 ::::
 
 ## Install
-::: warning Note 
-This plugin requires VuePress >= 1.0.0, for now you can try it via yarn add vuepress@next -D 
+::: warning Note
+This plugin requires VuePress >= 1.0.0
 :::
 
 ```

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,10 +1,10 @@
-import Tabs from './components/Tabs.vue'
-import TabPane from './components/Tab-pane.vue'
+import Tabs from './components/Tabs.vue';
+import TabPane from './components/Tab-pane.vue';
 
 import './theme/tabs.scss';
 
-export default function (ctx) {
-  const { Vue } = ctx
-  Vue.component('Tabs', Tabs)
-  Vue.component('Tab', TabPane)
+export default function(ctx) {
+  const { Vue } = ctx;
+  Vue.component('Tabs', Tabs);
+  Vue.component('Tab', TabPane);
 }

--- a/lib/markdownItPlugin.js
+++ b/lib/markdownItPlugin.js
@@ -1,59 +1,59 @@
-const { hash } = require('@vuepress/shared-utils')
-const container = require('markdown-it-container')
+const { hash } = require('@vuepress/shared-utils');
+const container = require('markdown-it-container');
 
-module.exports = function tabsPlugin (md, options = {}) {
-    options = options || {}
-    
-    md.use(container, 'tabs', {
-        render: (tokens, idx) => {
-            const token = tokens[idx]
-            const attributes = getTabsAttributes(token.info)
+module.exports = function tabsPlugin(md, options = {}) {
+  options = options || {};
 
-            if (token.nesting === 1) {
-                return `<Tabs ${attributes}>\n`
-            } else {
-                return `</Tabs>\n`
-            }
-        }
-    })
+  md.use(container, 'tabs', {
+    render: (tokens, idx) => {
+      const token = tokens[idx];
+      const attributes = getTabsAttributes(token.info);
 
-    md.use(container, 'tab', {
-        render: (tokens, idx) => {
-            const token = tokens[idx]
-            const attributes = getTabAttributes(token.info)
+      if (token.nesting === 1) {
+        return `<Tabs ${attributes}>\n`;
+      } else {
+        return `</Tabs>\n`;
+      }
+    },
+  });
 
-            if (token.nesting === 1) {
-                return `<Tab ${attributes}>\n`
-            } else {
-                return `</Tab>\n`
-            }
-        }
-    })
-}
+  md.use(container, 'tab', {
+    render: (tokens, idx) => {
+      const token = tokens[idx];
+      const attributes = getTabAttributes(token.info);
+
+      if (token.nesting === 1) {
+        return `<Tab ${attributes}>\n`;
+      } else {
+        return `</Tab>\n`;
+      }
+    },
+  });
+};
 
 function getTabsAttributes(info) {
-    var arr = info.split(' ')
-    var result = ''
-    if(arr.length > 2) {
-        arr.forEach(item => {
-            if(item !== '' && item !== 'tabs') {
-                var attribute = item.split(':')
-                result += `${attribute[0]}="${attribute[1]}" `
-            }
-        });
-    } else {
-        result = `type="border-card"`
-    }
-    return result
+  var arr = info.split(' ');
+  var result = '';
+  if (arr.length > 2) {
+    arr.forEach(item => {
+      if (item !== '' && item !== 'tabs') {
+        var attribute = item.split(':');
+        result += `${attribute[0]}="${attribute[1]}" `;
+      }
+    });
+  } else {
+    result = `type="border-card"`;
+  }
+  return result;
 }
 
 function getTabAttributes(info) {
-    var arr = info.split(' ')
-    if(arr.length == 3) {
-        return `label="${arr[2].trim()}"`
-    }
-    if(arr.length == 4) {
-        return `label=${arr[2].trim()} ${arr[3].trim()}`
-    }
-    return ''
+  var arr = info.split(' ');
+  if (arr.length == 3) {
+    return `label="${arr[2].trim()}"`;
+  }
+  if (arr.length == 4) {
+    return `label=${arr[2].trim()} ${arr[3].trim()}`;
+  }
+  return '';
 }

--- a/lib/utils/resize-event.js
+++ b/lib/utils/resize-event.js
@@ -28,7 +28,10 @@ export const addResizeListener = function(element, fn) {
 /* istanbul ignore next */
 export const removeResizeListener = function(element, fn) {
   if (!element || !element.__resizeListeners__) return;
-  element.__resizeListeners__.splice(element.__resizeListeners__.indexOf(fn), 1);
+  element.__resizeListeners__.splice(
+    element.__resizeListeners__.indexOf(fn),
+    1,
+  );
   if (!element.__resizeListeners__.length) {
     element.__ro__.disconnect();
   }

--- a/lib/utils/util.js
+++ b/lib/utils/util.js
@@ -25,7 +25,7 @@ export function toObject(arr) {
   return res;
 }
 
-export const getValueByPath = function(object, prop) {
+export const getValueByPath = (object, prop) => {
   prop = prop || '';
   const paths = prop.split('.');
   let current = object;
@@ -69,9 +69,7 @@ export function getPropByPath(obj, path, strict) {
   };
 }
 
-export const generateId = function() {
-  return Math.floor(Math.random() * 10000);
-};
+export const generateId = () => Math.floor(Math.random() * 10000);
 
 export const valueEquals = (a, b) => {
   // see: https://stackoverflow.com/questions/3115982/how-to-check-if-two-arrays-are-equal-with-javascript
@@ -89,7 +87,7 @@ export const escapeRegexpString = (value = '') =>
   String(value).replace(/[|\\{}()[\]^$+*?.]/g, '\\$&');
 
 // TODO: use native Array.find, Array.findIndex when IE support is dropped
-export const arrayFindIndex = function(arr, pred) {
+export const arrayFindIndex = (arr, pred) => {
   for (let i = 0; i !== arr.length; ++i) {
     if (pred(arr[i])) {
       return i;
@@ -98,13 +96,13 @@ export const arrayFindIndex = function(arr, pred) {
   return -1;
 };
 
-export const arrayFind = function(arr, pred) {
+export const arrayFind = (arr, pred) => {
   const idx = arrayFindIndex(arr, pred);
   return idx !== -1 ? arr[idx] : undefined;
 };
 
 // coerce truthy value to array
-export const coerceTruthyValueToArray = function(val) {
+export const coerceTruthyValueToArray = val => {
   if (Array.isArray(val)) {
     return val;
   } else if (val) {
@@ -114,15 +112,13 @@ export const coerceTruthyValueToArray = function(val) {
   }
 };
 
-export const isIE = function() {
-  return !Vue.prototype.$isServer && !isNaN(Number(document.documentMode));
-};
+export const isIE = () =>
+  !Vue.prototype.$isServer && !isNaN(Number(document.documentMode));
 
-export const isEdge = function() {
-  return !Vue.prototype.$isServer && navigator.userAgent.indexOf('Edge') > -1;
-};
+export const isEdge = () =>
+  !Vue.prototype.$isServer && navigator.userAgent.indexOf('Edge') > -1;
 
-export const autoprefixer = function(style) {
+export const autoprefixer = style => {
   if (typeof style !== 'object') return style;
   const rules = ['transform', 'transition', 'animation'];
   const prefixes = ['ms-', 'webkit-'];

--- a/lib/utils/util.js
+++ b/lib/utils/util.js
@@ -2,18 +2,18 @@ import Vue from 'vue';
 
 const hasOwnProperty = Object.prototype.hasOwnProperty;
 
-export function noop() {};
+export function noop() {}
 
 export function hasOwn(obj, key) {
   return hasOwnProperty.call(obj, key);
-};
+}
 
 function extend(to, _from) {
   for (let key in _from) {
     to[key] = _from[key];
   }
   return to;
-};
+}
 
 export function toObject(arr) {
   var res = {};
@@ -23,7 +23,7 @@ export function toObject(arr) {
     }
   }
   return res;
-};
+}
 
 export const getValueByPath = function(object, prop) {
   prop = prop || '';
@@ -65,9 +65,9 @@ export function getPropByPath(obj, path, strict) {
   return {
     o: tempObj,
     k: keyArr[i],
-    v: tempObj ? tempObj[keyArr[i]] : null
+    v: tempObj ? tempObj[keyArr[i]] : null,
   };
-};
+}
 
 export const generateId = function() {
   return Math.floor(Math.random() * 10000);
@@ -85,7 +85,8 @@ export const valueEquals = (a, b) => {
   return true;
 };
 
-export const escapeRegexpString = (value = '') => String(value).replace(/[|\\{}()[\]^$+*?.]/g, '\\$&');
+export const escapeRegexpString = (value = '') =>
+  String(value).replace(/[|\\{}()[\]^$+*?.]/g, '\\$&');
 
 // TODO: use native Array.find, Array.findIndex when IE support is dropped
 export const arrayFindIndex = function(arr, pred) {


### PR DESCRIPTION
.vue files end most statements with semicolons, use 2 spaces indentation, and end files with a newline. .js files should ideally match the same code style (909374352dc5d290232388e365e667111cd2113c)

VuePress 1.0.0 is officially released, so we can remove the warning now. (2ba73678186855d8415a1af8a3dd7bf5b1a973c5)

When using `export const` to export a function, `escapeRegexpString` is written in arrow function while others are written in normal function. This commit change every `export const` to arrow function. (15609d950d358610cfe6b7cda2dbd9bc4b2bc261)

Thank you!