### PR TITLE
multiple words to tab title

### DIFF
--- a/lib/markdownItPlugin.js
+++ b/lib/markdownItPlugin.js
@@ -49,11 +49,12 @@ function getTabsAttributes(info) {
 
 function getTabAttributes(info) {
   var arr = info.split(' ');
-  if (arr.length == 3) {
-    return `label="${arr[2].trim()}"`;
+  var last = arr.length - 1;
+  if (arr[last].trim() != "lazy") {
+    return `label="${arr.slice(2,last + 1).join(' ').trim()}"`;
   }
-  if (arr.length == 4) {
-    return `label=${arr[2].trim()} ${arr[3].trim()}`;
+  if (arr[last].trim() == "lazy") {
+    return `label="${arr.slice(2,last).join(' ').trim()}" ${arr[last].trim()}`;
   }
   return '';
 }


### PR DESCRIPTION
Fixed a logic error with multiple words in the same label title.